### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/ChrisMartin86/ScvmBot/security/code-scanning/1](https://github.com/ChrisMartin86/ScvmBot/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions` block either at the workflow root (applies to all jobs) or under the specific job, restricting the `GITHUB_TOKEN` to the minimum it needs. For this workflow, the steps only need to read repository contents (for `actions/checkout`) and do not need to write to repo contents, issues, or pull requests. `actions/upload-artifact` does not require repo write permissions. Therefore, the minimal safe and compatible configuration is `contents: read`.

The best fix without changing functionality is to add a workflow-level `permissions` block right under `name: Tests`, setting `contents: read`. This will apply to the `test` job (and any future jobs unless they override it) and satisfies CodeQL’s recommendation. Concretely, in `.github/workflows/tests.yml`, between lines 1 and 3, insert:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or other definitions are required, as this is purely a workflow YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
