### PR TITLE
Changed the guard to is not null and not "" so empty arrays fall thro…

### DIFF
--- a/src/ScvmBot.Bot/Services/CommandRegistrar.cs
+++ b/src/ScvmBot.Bot/Services/CommandRegistrar.cs
@@ -22,7 +22,8 @@ public static class CommandRegistrar
         var children = section.GetChildren().ToList();
 
         // A scalar value like "id1,id2" means someone used the wrong format.
-        if (children.Count == 0 && section.Value is not null)
+        // An empty JSON array [] produces Value="" with no children — that's fine.
+        if (children.Count == 0 && section.Value is not null and not "")
         {
             throw new InvalidOperationException(
                 $"Discord:GuildIds must be configured as an array " +

--- a/tests/ScvmBot.Bot.Tests/CommandRegistrarTests.cs
+++ b/tests/ScvmBot.Bot.Tests/CommandRegistrarTests.cs
@@ -42,6 +42,21 @@ public class CommandRegistrarTests
     }
 
     [Fact]
+    public void ResolveStrategy_EmptyJsonArray_ReturnsGlobal()
+    {
+        // An empty JSON array [] produces Value="" with no children in .NET config.
+        var config = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Discord:GuildIds"] = ""
+        });
+
+        var strategy = CommandRegistrar.ResolveStrategy(config);
+
+        Assert.Equal(RegistrationMode.Global, strategy.Mode);
+        Assert.Empty(strategy.GuildIds);
+    }
+
+    [Fact]
     public void ResolveStrategy_GuildIdsAllZero_Throws()
     {
         var config = BuildConfig(new Dictionary<string, string?>


### PR DESCRIPTION
…ugh to the "no children" path and correctly resolve as global registration. Added ResolveStrategy_EmptyJsonArray_ReturnsGlobal test to cover this exact case.