### PR TITLE
SharedTestInfrastructure.cs — Added TestDataBuilder with two methods:

### DIFF
--- a/tests/ScvmBot.Bot.Tests/CustomPdfTemplatePathTests.cs
+++ b/tests/ScvmBot.Bot.Tests/CustomPdfTemplatePathTests.cs
@@ -25,15 +25,7 @@ public class CustomPdfTemplatePathTests
     [Fact]
     public async Task Registration_UsesCustomPdfTemplate_WhenPresentInDataPath()
     {
-        var dir = TestInfrastructure.CreateTempDirectory();
-
-        // Create minimal data files
-        await File.WriteAllTextAsync(Path.Combine(dir, "classes.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "spells.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "names.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "weapons.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "armor.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "items.json"), "[]");
+        var dir = await TestDataBuilder.CreateMinimalDataDirectoryAsync();
 
         // Place a dummy PDF template in the custom data directory
         var templatePath = Path.Combine(dir, "character_sheet.pdf");
@@ -55,14 +47,7 @@ public class CustomPdfTemplatePathTests
     [Fact]
     public async Task RenderFile_UsesCustomTemplate_EndToEnd()
     {
-        var dir = TestInfrastructure.CreateTempDirectory();
-
-        await File.WriteAllTextAsync(Path.Combine(dir, "classes.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "spells.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "names.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "weapons.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "armor.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "items.json"), "[]");
+        var dir = await TestDataBuilder.CreateMinimalDataDirectoryAsync();
 
         // Copy the real PDF template from the repo (if available)
         var repoDataPath = Path.Combine(

--- a/tests/ScvmBot.Bot.Tests/GameModuleArchitectureTests.cs
+++ b/tests/ScvmBot.Bot.Tests/GameModuleArchitectureTests.cs
@@ -163,13 +163,7 @@ public class GameModuleArchitectureTests
         // Verify the registration delegate correctly sets up services
         var services = new ServiceCollection();
         // Simulate a successful registration by providing a test data directory
-        var dir = TestInfrastructure.CreateTempDirectory();
-        await File.WriteAllTextAsync(Path.Combine(dir, "classes.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "spells.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "names.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "weapons.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "armor.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "items.json"), "[]");
+        var dir = await TestDataBuilder.CreateMinimalDataDirectoryAsync();
 
         var config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?> { ["Modules:MorkBorg:DataPath"] = dir })
@@ -190,13 +184,7 @@ public class GameModuleArchitectureTests
     [Fact]
     public async Task MorkBorgModuleRegistration_ImplementsIModuleRegistration_AndRegistersServices()
     {
-        var dir = TestInfrastructure.CreateTempDirectory();
-        await File.WriteAllTextAsync(Path.Combine(dir, "classes.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "spells.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "names.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "weapons.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "armor.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "items.json"), "[]");
+        var dir = await TestDataBuilder.CreateMinimalDataDirectoryAsync();
 
         IModuleRegistration registration = new MorkBorgModuleRegistration();
         var config = new ConfigurationBuilder()

--- a/tests/ScvmBot.Bot.Tests/GenerateCommandHandlerTests.cs
+++ b/tests/ScvmBot.Bot.Tests/GenerateCommandHandlerTests.cs
@@ -439,13 +439,7 @@ public class GenerateCommandHandlerTests
 
     private static async Task<MorkBorgModule> CreateMinimalGameSystemAsync()
     {
-        var dir = TestInfrastructure.CreateTempDirectory();
-        await File.WriteAllTextAsync(Path.Combine(dir, "classes.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "spells.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "names.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "weapons.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "armor.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "items.json"), "[]");
+        var dir = await TestDataBuilder.CreateMinimalDataDirectoryAsync();
         var refData = await MorkBorgReferenceDataService.CreateAsync(dir);
         var generator = new CharacterGenerator(refData, new Random(42));
         return new MorkBorgModule(generator, refData);

--- a/tests/ScvmBot.Bot.Tests/ModuleBootstrapperTests.cs
+++ b/tests/ScvmBot.Bot.Tests/ModuleBootstrapperTests.cs
@@ -45,13 +45,7 @@ public class ModuleBootstrapperTests
     [Fact]
     public async Task DiscoverAndInitialize_WorksWithMinimalDataFiles()
     {
-        var dir = SharedTestInfrastructure.CreateTempDirectory();
-        await File.WriteAllTextAsync(Path.Combine(dir, "classes.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "spells.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "names.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "weapons.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "armor.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "items.json"), "[]");
+        var dir = await TestDataBuilder.CreateMinimalDataDirectoryAsync();
 
         var config = BuildConfig(new Dictionary<string, string?>
         {
@@ -95,13 +89,7 @@ public class ModuleBootstrapperTests
         // find without configuration. If config weren't passed to InitializeAsync,
         // the module would fall back to a default path that doesn't contain
         // these files and would fail with FileNotFoundException.
-        var dir = SharedTestInfrastructure.CreateTempDirectory();
-        await File.WriteAllTextAsync(Path.Combine(dir, "classes.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "spells.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "names.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "weapons.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "armor.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "items.json"), "[]");
+        var dir = await TestDataBuilder.CreateMinimalDataDirectoryAsync();
 
         var config = BuildConfig(new Dictionary<string, string?>
         {

--- a/tests/ScvmBot.Bot.Tests/MorkBorgGameSystemTests.cs
+++ b/tests/ScvmBot.Bot.Tests/MorkBorgGameSystemTests.cs
@@ -219,13 +219,7 @@ public class MorkBorgGameSystemTests
 
     private static async Task<MorkBorgModule> CreateMinimalGameSystemAsync()
     {
-        var dir = TestInfrastructure.CreateTempDirectory();
-        await File.WriteAllTextAsync(Path.Combine(dir, "classes.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "spells.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "names.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "weapons.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "armor.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "items.json"), "[]");
+        var dir = await TestDataBuilder.CreateMinimalDataDirectoryAsync();
         var refData = await MorkBorgReferenceDataService.CreateAsync(dir);
         var generator = new CharacterGenerator(refData, new Random(42));
         return new MorkBorgModule(generator, refData);

--- a/tests/ScvmBot.Bot.Tests/MorkBorgMultiCharacterGenerationTests.cs
+++ b/tests/ScvmBot.Bot.Tests/MorkBorgMultiCharacterGenerationTests.cs
@@ -157,13 +157,7 @@ public class MorkBorgMultiCharacterGenerationTests
 
     private static async Task<MorkBorgModule> CreateMinimalGameSystemAsync()
     {
-        var dir = TestInfrastructure.CreateTempDirectory();
-        await File.WriteAllTextAsync(Path.Combine(dir, "classes.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "spells.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "names.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "weapons.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "armor.json"), "[]");
-        await File.WriteAllTextAsync(Path.Combine(dir, "items.json"), "[]");
+        var dir = await TestDataBuilder.CreateMinimalDataDirectoryAsync();
         var refData = await MorkBorgReferenceDataService.CreateAsync(dir);
         var generator = new CharacterGenerator(refData, new Random(42));
         return new MorkBorgModule(generator, refData);

--- a/tests/ScvmBot.Tests.Shared/SharedTestInfrastructure.cs
+++ b/tests/ScvmBot.Tests.Shared/SharedTestInfrastructure.cs
@@ -67,3 +67,20 @@ public sealed class DeterministicRandom : Random
         return candidate;
     }
 }
+
+public static class TestDataBuilder
+{
+    private static readonly string[] MinimalDataFiles =
+        ["classes.json", "spells.json", "names.json", "weapons.json", "armor.json", "items.json"];
+
+    public static async Task<string> CreateMinimalDataDirectoryAsync()
+    {
+        var dir = SharedTestInfrastructure.CreateTempDirectory();
+        foreach (var file in MinimalDataFiles)
+            await File.WriteAllTextAsync(Path.Combine(dir, file), "[]");
+        return dir;
+    }
+
+    public static string GetRealDataDirectoryPath() =>
+        Path.Combine(SharedTestInfrastructure.GetRepositoryRoot(), "src", "ScvmBot.Games.MorkBorg", "Data");
+}


### PR DESCRIPTION
CreateMinimalDataDirectoryAsync() — creates temp dir + writes the 6 empty JSON files, returns the path GetRealDataDirectoryPath() — returns the path to the bundled Data 6 test files updated — all 9 duplicate 6-file-write blocks replaced with a single await TestDataBuilder.CreateMinimalDataDirectoryAsync() call:

GameModuleArchitectureTests.cs (2 sites)
GenerateCommandHandlerTests.cs (1 site)
CustomPdfTemplatePathTests.cs (2 sites)
ModuleBootstrapperTests.cs (2 sites)
MorkBorgGameSystemTests.cs (1 site)
MorkBorgMultiCharacterGenerationTests.cs (1 site)