### PR TITLE
42 extract cli help rendering out of programcs

### DIFF
--- a/src/ScvmBot.Cli/CliHelpRenderer.cs
+++ b/src/ScvmBot.Cli/CliHelpRenderer.cs
@@ -28,7 +28,7 @@ internal static class CliHelpRenderer
         }
     }
 
-    internal static void PrintUsage(Dictionary<string, IGameModule> gameModules)
+    internal static void PrintUsage(IReadOnlyDictionary<string, IGameModule> gameModules)
     {
         Console.WriteLine("Usage: scvmbot-cli [--data <path>] generate <game> <subcommand> [options]");
         Console.WriteLine();

--- a/src/ScvmBot.Cli/Program.cs
+++ b/src/ScvmBot.Cli/Program.cs
@@ -31,7 +31,7 @@ try
 }
 catch (Exception ex) when (showHelp)
 {
-    CliHelpRenderer.PrintUsage([]);
+    CliHelpRenderer.PrintUsage(new Dictionary<string, IGameModule>());
     Console.Error.WriteLine();
     Console.Error.WriteLine($"  (Module details unavailable: {ex.Message})");;
     return 0;


### PR DESCRIPTION
## Summary

Extracts CLI help and card rendering out of `Program.cs` into a dedicated `CliHelpRenderer`.

This keeps the entrypoint focused on startup, command parsing, and execution flow while moving console presentation logic into its own class.

## What changed

- Added `CliHelpRenderer`
- Moved `PrintUsage()` out of `Program.cs`
- Moved `PrintCard()` out of `Program.cs`
- Updated `Program.cs` to call the renderer instead of owning formatting logic directly

## Why

`Program.cs` had accumulated a large block of help and output formatting code that did not belong in the entrypoint. Pulling that logic into a dedicated renderer makes the CLI easier to read, easier to maintain, and easier to extend later without turning the startup path into a junk drawer.

## Notes

This change is intended to address issue #42 and replaces the CLI help-rendering portion of #29.