### PR TITLE
Issue 41: extract CLI benchmark mode into dedicated runner

### DIFF
--- a/src/ScvmBot.Cli/CliBenchmarkRunner.cs
+++ b/src/ScvmBot.Cli/CliBenchmarkRunner.cs
@@ -1,0 +1,77 @@
+using ScvmBot.Modules;
+using System.Diagnostics;
+
+namespace ScvmBot.Cli;
+
+/// <summary>
+/// Executes benchmark mode (<c>--quiet</c>) for a CLI generation command,
+/// handling iteration timing and console output. Extracted from Program.cs
+/// so that the entrypoint remains a thin composition layer.
+/// </summary>
+internal static class CliBenchmarkRunner
+{
+    internal static async Task RunAsync(
+        IGameModule module,
+        string subCommandName,
+        IReadOnlyDictionary<string, object?> options,
+        CliOptions cliOpts,
+        CancellationToken ct)
+    {
+        if (cliOpts.Detailed)
+        {
+            var ticksPerGeneration = new long[cliOpts.Count];
+            var sw = new Stopwatch();
+            var startTime = DateTimeOffset.Now;
+            var totalSw = Stopwatch.StartNew();
+
+            for (var n = 0; n < cliOpts.Count; n++)
+            {
+                sw.Restart();
+                await module.HandleGenerateCommandAsync(subCommandName, options, ct);
+                sw.Stop();
+                ticksPerGeneration[n] = sw.ElapsedTicks;
+            }
+
+            totalSw.Stop();
+            var endTime = DateTimeOffset.Now;
+
+            Array.Sort(ticksPerGeneration);
+            var tickFreq = (double)Stopwatch.Frequency;
+            var minMs = ticksPerGeneration[0] / tickFreq * 1000;
+            var maxMs = ticksPerGeneration[cliOpts.Count - 1] / tickFreq * 1000;
+            var medianMs = ticksPerGeneration[cliOpts.Count / 2] / tickFreq * 1000;
+            var avgMs = ticksPerGeneration.Average() / tickFreq * 1000;
+            var p95Ms = ticksPerGeneration[(int)(cliOpts.Count * 0.95)] / tickFreq * 1000;
+            var p99Ms = ticksPerGeneration[(int)(cliOpts.Count * 0.99)] / tickFreq * 1000;
+
+            Console.WriteLine($"  Started:   {startTime:yyyy-MM-dd HH:mm:ss.fff zzz}");
+            Console.WriteLine($"  Finished:  {endTime:yyyy-MM-dd HH:mm:ss.fff zzz}");
+            Console.WriteLine($"  Count:     {cliOpts.Count:N0}");
+            Console.WriteLine($"  Elapsed:   {totalSw.Elapsed}");
+            Console.WriteLine();
+            Console.WriteLine("  Per-generation timing:");
+            Console.WriteLine($"    Min:     {minMs:F4} ms");
+            Console.WriteLine($"    Max:     {maxMs:F4} ms");
+            Console.WriteLine($"    Avg:     {avgMs:F4} ms");
+            Console.WriteLine($"    Median:  {medianMs:F4} ms");
+            Console.WriteLine($"    P95:     {p95Ms:F4} ms");
+            Console.WriteLine($"    P99:     {p99Ms:F4} ms");
+        }
+        else
+        {
+            var startTime = DateTimeOffset.Now;
+            var sw = Stopwatch.StartNew();
+
+            for (var n = 0; n < cliOpts.Count; n++)
+                await module.HandleGenerateCommandAsync(subCommandName, options, ct);
+
+            sw.Stop();
+            var endTime = DateTimeOffset.Now;
+
+            Console.WriteLine($"  Started:   {startTime:yyyy-MM-dd HH:mm:ss.fff zzz}");
+            Console.WriteLine($"  Finished:  {endTime:yyyy-MM-dd HH:mm:ss.fff zzz}");
+            Console.WriteLine($"  Count:     {cliOpts.Count:N0}");
+            Console.WriteLine($"  Elapsed:   {sw.Elapsed}");
+        }
+    }
+}

--- a/src/ScvmBot.Cli/Program.cs
+++ b/src/ScvmBot.Cli/Program.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using ScvmBot.Cli;
 using ScvmBot.Modules;
-using System.Diagnostics;
 
 // ── Cancellation support (Ctrl+C) ───────────────────────────────────────
 using var cts = new CancellationTokenSource();
@@ -96,62 +95,7 @@ if (cliOpts.Quiet)
     benchOptions.Remove("count");
     benchOptions.Remove("name");
 
-    if (cliOpts.Detailed)
-    {
-        var ticksPerGeneration = new long[cliOpts.Count];
-        var sw = new Stopwatch();
-        var startTime = DateTimeOffset.Now;
-        var totalSw = Stopwatch.StartNew();
-
-        for (var n = 0; n < cliOpts.Count; n++)
-        {
-            sw.Restart();
-            await module.HandleGenerateCommandAsync(subCommandDef.Name, benchOptions, ct);
-            sw.Stop();
-            ticksPerGeneration[n] = sw.ElapsedTicks;
-        }
-
-        totalSw.Stop();
-        var endTime = DateTimeOffset.Now;
-
-        Array.Sort(ticksPerGeneration);
-        var tickFreq = (double)Stopwatch.Frequency;
-        var minMs = ticksPerGeneration[0] / tickFreq * 1000;
-        var maxMs = ticksPerGeneration[cliOpts.Count - 1] / tickFreq * 1000;
-        var medianMs = ticksPerGeneration[cliOpts.Count / 2] / tickFreq * 1000;
-        var avgMs = ticksPerGeneration.Average() / tickFreq * 1000;
-        var p95Ms = ticksPerGeneration[(int)(cliOpts.Count * 0.95)] / tickFreq * 1000;
-        var p99Ms = ticksPerGeneration[(int)(cliOpts.Count * 0.99)] / tickFreq * 1000;
-
-        Console.WriteLine($"  Started:   {startTime:yyyy-MM-dd HH:mm:ss.fff zzz}");
-        Console.WriteLine($"  Finished:  {endTime:yyyy-MM-dd HH:mm:ss.fff zzz}");
-        Console.WriteLine($"  Count:     {cliOpts.Count:N0}");
-        Console.WriteLine($"  Elapsed:   {totalSw.Elapsed}");
-        Console.WriteLine();
-        Console.WriteLine("  Per-generation timing:");
-        Console.WriteLine($"    Min:     {minMs:F4} ms");
-        Console.WriteLine($"    Max:     {maxMs:F4} ms");
-        Console.WriteLine($"    Avg:     {avgMs:F4} ms");
-        Console.WriteLine($"    Median:  {medianMs:F4} ms");
-        Console.WriteLine($"    P95:     {p95Ms:F4} ms");
-        Console.WriteLine($"    P99:     {p99Ms:F4} ms");
-    }
-    else
-    {
-        var startTime = DateTimeOffset.Now;
-        var sw = Stopwatch.StartNew();
-
-        for (var n = 0; n < cliOpts.Count; n++)
-            await module.HandleGenerateCommandAsync(subCommandDef.Name, benchOptions, ct);
-
-        sw.Stop();
-        var endTime = DateTimeOffset.Now;
-
-        Console.WriteLine($"  Started:   {startTime:yyyy-MM-dd HH:mm:ss.fff zzz}");
-        Console.WriteLine($"  Finished:  {endTime:yyyy-MM-dd HH:mm:ss.fff zzz}");
-        Console.WriteLine($"  Count:     {cliOpts.Count:N0}");
-        Console.WriteLine($"  Elapsed:   {sw.Elapsed}");
-    }
+    await CliBenchmarkRunner.RunAsync(module, subCommandDef.Name, benchOptions, cliOpts, ct);
     return 0;
 }
 


### PR DESCRIPTION
## Summary

Extracts CLI benchmark mode out of `Program.cs` into a dedicated `CliBenchmarkRunner`.

This keeps the entrypoint focused on startup, command parsing, and normal execution flow while moving benchmark-specific timing and output behavior into its own class.

## What changed

- Added `CliBenchmarkRunner`
- Moved `--quiet` benchmark execution out of `Program.cs`
- Moved benchmark timing loops and reporting into the runner
- Updated `Program.cs` to delegate benchmark mode to the runner

## Why

The benchmark path was the largest single block in `Program.cs` and was independent from the normal generation flow. Pulling it into a dedicated runner makes the entrypoint easier to read, easier to maintain, and easier to extend later without piling more mode-specific behavior into the top-level program file.

## Notes

This change addresses issue #41 and replaces the benchmark portion of #29.