### PR TITLE
Issue 43: extract random selection into MorkBorgRandomPicker

### DIFF
--- a/src/ScvmBot.Games.MorkBorg/Generation/CharacterGenerator.cs
+++ b/src/ScvmBot.Games.MorkBorg/Generation/CharacterGenerator.cs
@@ -6,7 +6,6 @@ namespace ScvmBot.Games.MorkBorg.Generation;
 public sealed class CharacterGenerator
 {
     private readonly MorkBorgReferenceDataService _refData;
-    private readonly Random _rng;
     private readonly DiceRoller _dice;
     private readonly AbilityRoller _abilityRoller;
     private readonly WeaponResolver _weaponResolver;
@@ -14,6 +13,7 @@ public sealed class CharacterGenerator
     private readonly ScrollResolver _scrollResolver;
     private readonly StartingGearTable _startingGearTable;
     private readonly VignetteGenerator _vignetteGenerator;
+    private readonly MorkBorgRandomPicker _picker;
 
     /// <summary>Primary constructor — all collaborators are injected (used by DI).</summary>
     public CharacterGenerator(
@@ -25,10 +25,9 @@ public sealed class CharacterGenerator
         ScrollResolver scrollResolver,
         StartingGearTable startingGearTable,
         VignetteGenerator vignetteGenerator,
-        Random rng)
+        MorkBorgRandomPicker picker)
     {
         _refData = refData;
-        _rng = rng;
         _dice = dice;
         _abilityRoller = abilityRoller;
         _weaponResolver = weaponResolver;
@@ -36,6 +35,7 @@ public sealed class CharacterGenerator
         _scrollResolver = scrollResolver;
         _startingGearTable = startingGearTable;
         _vignetteGenerator = vignetteGenerator;
+        _picker = picker;
     }
 
     public Character Generate(
@@ -46,7 +46,7 @@ public sealed class CharacterGenerator
         var name = options.Name;
         if (string.IsNullOrWhiteSpace(name))
         {
-            name = _refData.GetRandomName(_rng);
+            name = _picker.PickName();
         }
 
         var classData = ResolveClass(options);
@@ -86,9 +86,9 @@ public sealed class CharacterGenerator
             _scrollResolver.ResolveStartingScrolls(classData, scrollsList);
         }
 
-        descriptionsList.Add(new CharacterDescription(DescriptionCategory.Trait, _refData.GetRandomTrait(_rng)));
-        descriptionsList.Add(new CharacterDescription(DescriptionCategory.Body, _refData.GetRandomBody(_rng)));
-        descriptionsList.Add(new CharacterDescription(DescriptionCategory.Habit, _refData.GetRandomHabit(_rng)));
+        descriptionsList.Add(new CharacterDescription(DescriptionCategory.Trait, _picker.PickTrait()));
+        descriptionsList.Add(new CharacterDescription(DescriptionCategory.Body, _picker.PickBody()));
+        descriptionsList.Add(new CharacterDescription(DescriptionCategory.Habit, _picker.PickHabit()));
 
         var character = new Character
         {
@@ -134,7 +134,7 @@ public sealed class CharacterGenerator
         {
             // 50/50 classless vs classed: d6 1-3 = classless, 4-6 = random class
             var roll = _dice.RollDie(6);
-            return roll <= 3 ? null : _refData.GetRandomClass(_rng);
+            return roll <= 3 ? null : _picker.PickClass();
         }
 
         // empty string => backward compat, treat as classless

--- a/src/ScvmBot.Games.MorkBorg/Generation/CharacterGeneratorFactory.cs
+++ b/src/ScvmBot.Games.MorkBorg/Generation/CharacterGeneratorFactory.cs
@@ -13,7 +13,8 @@ public static class CharacterGeneratorFactory
     {
         var resolvedRng = rng ?? Random.Shared;
         var dice = new DiceRoller(resolvedRng);
-        var scrollResolver = new ScrollResolver(refData, resolvedRng);
+        var picker = new ScvmBot.Games.MorkBorg.Reference.MorkBorgRandomPicker(refData, resolvedRng);
+        var scrollResolver = new ScrollResolver(refData, picker);
         return new CharacterGenerator(
             refData,
             dice,
@@ -21,8 +22,8 @@ public static class CharacterGeneratorFactory
             new WeaponResolver(refData, dice, resolvedRng),
             new ArmorResolver(refData, dice, resolvedRng),
             scrollResolver,
-            new StartingGearTable(refData, dice, scrollResolver, resolvedRng),
+            new StartingGearTable(refData, dice, scrollResolver, picker),
             new VignetteGenerator(refData.Vignettes, resolvedRng),
-            resolvedRng);
+            picker);
     }
 }

--- a/src/ScvmBot.Games.MorkBorg/Generation/ScrollResolver.cs
+++ b/src/ScvmBot.Games.MorkBorg/Generation/ScrollResolver.cs
@@ -5,27 +5,15 @@ namespace ScvmBot.Games.MorkBorg.Generation;
 public sealed class ScrollResolver
 {
     private readonly MorkBorgReferenceDataService _refData;
-    private readonly Random _rng;
+    private readonly MorkBorgRandomPicker _picker;
 
-    public ScrollResolver(MorkBorgReferenceDataService refData, Random rng)
+    public ScrollResolver(MorkBorgReferenceDataService refData, MorkBorgRandomPicker picker)
     {
         _refData = refData;
-        _rng = rng;
+        _picker = picker;
     }
 
-    public string GetRandomAnyScroll()
-    {
-        var all = _refData.Scrolls
-            .Where(s => s.Kind == ScrollKind.Sacred || s.Kind == ScrollKind.Unclean)
-            .ToList();
-
-        if (all.Count == 0)
-        {
-            throw new InvalidOperationException("No sacred or unclean scrolls are available.");
-        }
-
-        return all[_rng.Next(all.Count)].ToFormattedString();
-    }
+    public string GetRandomAnyScroll() => _picker.PickAnyScroll();
 
     public void ResolveStartingScrolls(ClassData classData, List<string> scrollsList)
     {
@@ -36,7 +24,7 @@ public sealed class ScrollResolver
         {
             if (scrollKey == MorkBorgConstants.ScrollToken.RandomUnclean)
             {
-                var scroll = _refData.GetRandomScroll(ScrollKind.Unclean, _rng);
+                var scroll = _picker.PickScroll(ScrollKind.Unclean);
                 if (scroll is null)
                     throw new InvalidOperationException(
                         $"Class '{classData.Name}' requires an Unclean scroll but no Unclean scrolls exist in the data.");
@@ -44,7 +32,7 @@ public sealed class ScrollResolver
             }
             else if (scrollKey == MorkBorgConstants.ScrollToken.RandomSacred)
             {
-                var scroll = _refData.GetRandomScroll(ScrollKind.Sacred, _rng);
+                var scroll = _picker.PickScroll(ScrollKind.Sacred);
                 if (scroll is null)
                     throw new InvalidOperationException(
                         $"Class '{classData.Name}' requires a Sacred scroll but no Sacred scrolls exist in the data.");
@@ -67,7 +55,7 @@ public sealed class ScrollResolver
         switch (token.ToLowerInvariant())
         {
             case MorkBorgConstants.ScrollToken.RandomSacredScroll:
-                var sacredScroll = _refData.GetRandomScroll(ScrollKind.Sacred, _rng);
+                var sacredScroll = _picker.PickScroll(ScrollKind.Sacred);
                 if (sacredScroll is null)
                     throw new InvalidOperationException(
                         "A Sacred scroll is required by starting item data but no Sacred scrolls exist in the data.");
@@ -75,7 +63,7 @@ public sealed class ScrollResolver
                 return true;
 
             case MorkBorgConstants.ScrollToken.RandomUncleanScroll:
-                var uncleanScroll = _refData.GetRandomScroll(ScrollKind.Unclean, _rng);
+                var uncleanScroll = _picker.PickScroll(ScrollKind.Unclean);
                 if (uncleanScroll is null)
                     throw new InvalidOperationException(
                         "An Unclean scroll is required by starting item data but no Unclean scrolls exist in the data.");

--- a/src/ScvmBot.Games.MorkBorg/Generation/StartingGearTable.cs
+++ b/src/ScvmBot.Games.MorkBorg/Generation/StartingGearTable.cs
@@ -8,18 +8,18 @@ public sealed class StartingGearTable
     private readonly MorkBorgReferenceDataService _refData;
     private readonly DiceRoller _dice;
     private readonly ScrollResolver _scrollResolver;
-    private readonly Random _rng;
+    private readonly MorkBorgRandomPicker _picker;
 
     public StartingGearTable(
         MorkBorgReferenceDataService refData,
         DiceRoller dice,
         ScrollResolver scrollResolver,
-        Random rng)
+        MorkBorgRandomPicker picker)
     {
         _refData = refData;
         _dice = dice;
         _scrollResolver = scrollResolver;
-        _rng = rng;
+        _picker = picker;
     }
 
     public void ApplyStartingEquipment(
@@ -271,7 +271,7 @@ public sealed class StartingGearTable
                 break;
 
             case 11:
-                var scroll = _refData.GetRandomScroll(ScrollKind.Sacred, _rng);
+                var scroll = _picker.PickScroll(ScrollKind.Sacred);
                 if (scroll != null)
                 {
                     scrolls.Add(scroll.ToFormattedString());

--- a/src/ScvmBot.Games.MorkBorg/Reference/MorkBorgRandomPicker.cs
+++ b/src/ScvmBot.Games.MorkBorg/Reference/MorkBorgRandomPicker.cs
@@ -1,0 +1,72 @@
+using ScvmBot.Games.MorkBorg.Models;
+
+namespace ScvmBot.Games.MorkBorg.Reference;
+
+/// <summary>
+/// Handles all random-selection operations against loaded reference data.
+/// Keeps random-selection logic out of <see cref="MorkBorgReferenceDataService"/>,
+/// which is responsible only for data loading and indexed lookup.
+/// </summary>
+public sealed class MorkBorgRandomPicker
+{
+    private readonly MorkBorgReferenceDataService _refData;
+    private readonly Random _rng;
+
+    public MorkBorgRandomPicker(MorkBorgReferenceDataService refData, Random rng)
+    {
+        _refData = refData;
+        _rng = rng;
+    }
+
+    public string PickName() =>
+        _refData.Names.Count > 0 ? _refData.Names[_rng.Next(_refData.Names.Count)] : "Unknown";
+
+    public WeaponData? PickWeapon() =>
+        _refData.Weapons.Count > 0 ? _refData.Weapons[_rng.Next(_refData.Weapons.Count)] : null;
+
+    public ArmorData? PickArmor() =>
+        _refData.Armor.Count > 0 ? _refData.Armor[_rng.Next(_refData.Armor.Count)] : null;
+
+    public ItemData? PickItem() =>
+        _refData.Items.Count > 0 ? _refData.Items[_rng.Next(_refData.Items.Count)] : null;
+
+    public ClassData? PickClass() =>
+        _refData.Classes.Count > 0 ? _refData.Classes[_rng.Next(_refData.Classes.Count)] : null;
+
+    public string PickTrait() =>
+        _refData.Descriptions.Trait.Count > 0
+            ? _refData.Descriptions.Trait[_rng.Next(_refData.Descriptions.Trait.Count)]
+            : "";
+
+    public string PickBody() =>
+        _refData.Descriptions.BrokenBody.Count > 0
+            ? _refData.Descriptions.BrokenBody[_rng.Next(_refData.Descriptions.BrokenBody.Count)]
+            : "";
+
+    public string PickHabit() =>
+        _refData.Descriptions.BadHabit.Count > 0
+            ? _refData.Descriptions.BadHabit[_rng.Next(_refData.Descriptions.BadHabit.Count)]
+            : "";
+
+    public ScrollData? PickScroll(ScrollKind kind)
+    {
+        var matching = _refData.Scrolls.Where(s => s.Kind == kind).ToList();
+        return matching.Count > 0 ? matching[_rng.Next(matching.Count)] : null;
+    }
+
+    /// <summary>
+    /// Picks uniformly from the merged pool of Sacred and Unclean scrolls.
+    /// Throws if no scrolls of either kind exist.
+    /// </summary>
+    public string PickAnyScroll()
+    {
+        var all = _refData.Scrolls
+            .Where(s => s.Kind == ScrollKind.Sacred || s.Kind == ScrollKind.Unclean)
+            .ToList();
+
+        if (all.Count == 0)
+            throw new InvalidOperationException("No sacred or unclean scrolls are available.");
+
+        return all[_rng.Next(all.Count)].ToFormattedString();
+    }
+}

--- a/src/ScvmBot.Games.MorkBorg/Reference/ReferenceDataService.cs
+++ b/src/ScvmBot.Games.MorkBorg/Reference/ReferenceDataService.cs
@@ -146,25 +146,7 @@ public class MorkBorgReferenceDataService
         }
     }
 
-    public string GetRandomName(Random random)
-    {
-        return _names.Count > 0 ? _names[random.Next(_names.Count)] : "Unknown";
-    }
 
-    public WeaponData? GetRandomWeapon(Random random)
-    {
-        return _weapons.Count > 0 ? _weapons[random.Next(_weapons.Count)] : null;
-    }
-
-    public ArmorData? GetRandomArmor(Random random)
-    {
-        return _armor.Count > 0 ? _armor[random.Next(_armor.Count)] : null;
-    }
-
-    public ItemData? GetRandomItem(Random random)
-    {
-        return _items.Count > 0 ? _items[random.Next(_items.Count)] : null;
-    }
 
     public WeaponData? GetWeaponByTableIndex(int tableIndex)
     {
@@ -191,28 +173,9 @@ public class MorkBorgReferenceDataService
         return _items.FirstOrDefault(i => i.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
     }
 
-    public string GetRandomTrait(Random random) =>
-        _descriptions.Trait.Count > 0 ? _descriptions.Trait[random.Next(_descriptions.Trait.Count)] : "";
-
-    public string GetRandomBody(Random random) =>
-        _descriptions.BrokenBody.Count > 0 ? _descriptions.BrokenBody[random.Next(_descriptions.BrokenBody.Count)] : "";
-
-    public string GetRandomHabit(Random random) =>
-        _descriptions.BadHabit.Count > 0 ? _descriptions.BadHabit[random.Next(_descriptions.BadHabit.Count)] : "";
-
-    public ClassData? GetRandomClass(Random random)
-    {
-        return _classes.Count > 0 ? _classes[random.Next(_classes.Count)] : null;
-    }
-
     public ClassData? GetClassByName(string name)
     {
         return _classes.FirstOrDefault(c => c.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
     }
 
-    public ScrollData? GetRandomScroll(ScrollKind kind, Random random)
-    {
-        var matching = _scrolls.Where(s => s.Kind == kind).ToList();
-        return matching.Count > 0 ? matching[random.Next(matching.Count)] : null;
-    }
 }

--- a/src/ScvmBot.Modules.MorkBorg/MorkBorgModuleRegistration.cs
+++ b/src/ScvmBot.Modules.MorkBorg/MorkBorgModuleRegistration.cs
@@ -41,6 +41,7 @@ public sealed class MorkBorgModuleRegistration : IModuleRegistration
         {
             services.AddSingleton(Random.Shared);
             services.AddSingleton(refData);
+            services.AddSingleton<MorkBorgRandomPicker>();
             services.AddSingleton<DiceRoller>();
             services.AddSingleton<AbilityRoller>();
             services.AddSingleton<WeaponResolver>();

--- a/tests/ScvmBot.Games.MorkBorg.Tests/MorkBorgScrollMechanicsTests.cs
+++ b/tests/ScvmBot.Games.MorkBorg.Tests/MorkBorgScrollMechanicsTests.cs
@@ -131,12 +131,12 @@ public class MorkBorgScrollMechanicsTests : MorkBorgGameRulesFixture
     public async Task GetRandomScroll_ReturnsValidScrollOfRequestedType()
     {
         var referenceData = await LoadGameReferenceDataAsync();
-        var rng = new Random(333);
+        var picker = new MorkBorgRandomPicker(referenceData, new Random(333));
 
         for (int i = 0; i < 20; i++)
         {
-            var sacredScroll = referenceData.GetRandomScroll(ScrollKind.Sacred, rng);
-            var uncleanScroll = referenceData.GetRandomScroll(ScrollKind.Unclean, rng);
+            var sacredScroll = picker.PickScroll(ScrollKind.Sacred);
+            var uncleanScroll = picker.PickScroll(ScrollKind.Unclean);
 
             Assert.NotNull(sacredScroll);
             Assert.Equal(ScrollKind.Sacred, sacredScroll.Kind);

--- a/tests/ScvmBot.Games.MorkBorg.Tests/ReferenceDataServiceErrorTests.cs
+++ b/tests/ScvmBot.Games.MorkBorg.Tests/ReferenceDataServiceErrorTests.cs
@@ -190,7 +190,7 @@ public class ReferenceDataServiceErrorTests
     }
 
     [Fact]
-    public async Task GetRandomName_ReturnsUnknown_WhenNamesListIsEmpty()
+    public async Task PickName_ReturnsUnknown_WhenNamesListIsEmpty()
     {
         var dir = TestUtilities.CreateTempDirectory();
         try
@@ -202,7 +202,8 @@ public class ReferenceDataServiceErrorTests
             await File.WriteAllTextAsync(Path.Combine(dir, "armor.json"), "[]");
             await File.WriteAllTextAsync(Path.Combine(dir, "items.json"), "[]");
             var service = await MorkBorgReferenceDataService.CreateAsync(dir);
-            Assert.Equal("Unknown", service.GetRandomName(new Random(42)));
+            var picker = new MorkBorgRandomPicker(service, new Random(42));
+            Assert.Equal("Unknown", picker.PickName());
         }
         finally
         {
@@ -211,7 +212,7 @@ public class ReferenceDataServiceErrorTests
     }
 
     [Fact]
-    public async Task GetRandomWeapon_ReturnsNull_WhenWeaponsEmpty()
+    public async Task PickWeapon_ReturnsNull_WhenWeaponsEmpty()
     {
         var dir = TestUtilities.CreateTempDirectory();
         try
@@ -223,7 +224,8 @@ public class ReferenceDataServiceErrorTests
             await File.WriteAllTextAsync(Path.Combine(dir, "armor.json"), "[]");
             await File.WriteAllTextAsync(Path.Combine(dir, "items.json"), "[]");
             var service = await MorkBorgReferenceDataService.CreateAsync(dir);
-            Assert.Null(service.GetRandomWeapon(new Random(42)));
+            var picker = new MorkBorgRandomPicker(service, new Random(42));
+            Assert.Null(picker.PickWeapon());
         }
         finally
         {
@@ -232,7 +234,7 @@ public class ReferenceDataServiceErrorTests
     }
 
     [Fact]
-    public async Task GetRandomArmor_ReturnsNull_WhenArmorEmpty()
+    public async Task PickArmor_ReturnsNull_WhenArmorEmpty()
     {
         var dir = TestUtilities.CreateTempDirectory();
         try
@@ -244,7 +246,8 @@ public class ReferenceDataServiceErrorTests
             await File.WriteAllTextAsync(Path.Combine(dir, "armor.json"), "[]");
             await File.WriteAllTextAsync(Path.Combine(dir, "items.json"), "[]");
             var service = await MorkBorgReferenceDataService.CreateAsync(dir);
-            Assert.Null(service.GetRandomArmor(new Random(42)));
+            var picker = new MorkBorgRandomPicker(service, new Random(42));
+            Assert.Null(picker.PickArmor());
         }
         finally
         {
@@ -253,7 +256,7 @@ public class ReferenceDataServiceErrorTests
     }
 
     [Fact]
-    public async Task GetRandomItem_ReturnsNull_WhenItemsEmpty()
+    public async Task PickItem_ReturnsNull_WhenItemsEmpty()
     {
         var dir = TestUtilities.CreateTempDirectory();
         try
@@ -265,7 +268,8 @@ public class ReferenceDataServiceErrorTests
             await File.WriteAllTextAsync(Path.Combine(dir, "armor.json"), "[]");
             await File.WriteAllTextAsync(Path.Combine(dir, "items.json"), "[]");
             var service = await MorkBorgReferenceDataService.CreateAsync(dir);
-            Assert.Null(service.GetRandomItem(new Random(42)));
+            var picker = new MorkBorgRandomPicker(service, new Random(42));
+            Assert.Null(picker.PickItem());
         }
         finally
         {
@@ -274,7 +278,7 @@ public class ReferenceDataServiceErrorTests
     }
 
     [Fact]
-    public async Task GetRandomClass_ReturnsNull_WhenClassesEmpty()
+    public async Task PickClass_ReturnsNull_WhenClassesEmpty()
     {
         var dir = TestUtilities.CreateTempDirectory();
         try
@@ -286,7 +290,8 @@ public class ReferenceDataServiceErrorTests
             await File.WriteAllTextAsync(Path.Combine(dir, "armor.json"), "[]");
             await File.WriteAllTextAsync(Path.Combine(dir, "items.json"), "[]");
             var service = await MorkBorgReferenceDataService.CreateAsync(dir);
-            Assert.Null(service.GetRandomClass(new Random(42)));
+            var picker = new MorkBorgRandomPicker(service, new Random(42));
+            Assert.Null(picker.PickClass());
         }
         finally
         {
@@ -295,7 +300,7 @@ public class ReferenceDataServiceErrorTests
     }
 
     [Fact]
-    public async Task GetRandomScroll_ReturnsNull_WhenNoScrollsOfType()
+    public async Task PickScroll_ReturnsNull_WhenNoScrollsOfType()
     {
         var dir = TestUtilities.CreateTempDirectory();
         try
@@ -307,7 +312,8 @@ public class ReferenceDataServiceErrorTests
             await File.WriteAllTextAsync(Path.Combine(dir, "armor.json"), "[]");
             await File.WriteAllTextAsync(Path.Combine(dir, "items.json"), "[]");
             var service = await MorkBorgReferenceDataService.CreateAsync(dir);
-            Assert.Null(service.GetRandomScroll(ScrollKind.Sacred, new Random(42)));
+            var picker = new MorkBorgRandomPicker(service, new Random(42));
+            Assert.Null(picker.PickScroll(ScrollKind.Sacred));
         }
         finally
         {

--- a/tests/ScvmBot.Games.MorkBorg.Tests/WholeSystemAuditTests.cs
+++ b/tests/ScvmBot.Games.MorkBorg.Tests/WholeSystemAuditTests.cs
@@ -576,11 +576,12 @@ public class WholeSystemAuditTests : MorkBorgGameRulesFixture
     {
         var refData = await LoadGameReferenceDataAsync();
         var rng = new Random(42);
+        var picker = new MorkBorgRandomPicker(refData, rng);
 
         for (int i = 0; i < 50; i++)
         {
-            Assert.NotNull(refData.GetRandomScroll(ScrollKind.Sacred, rng));
-            Assert.NotNull(refData.GetRandomScroll(ScrollKind.Unclean, rng));
+            Assert.NotNull(picker.PickScroll(ScrollKind.Sacred));
+            Assert.NotNull(picker.PickScroll(ScrollKind.Unclean));
         }
     }
 
@@ -653,11 +654,11 @@ public class WholeSystemAuditTests : MorkBorgGameRulesFixture
     public async Task C4_RequiredDescriptionTables_AreNonEmpty()
     {
         var refData = await LoadGameReferenceDataAsync();
-        var rng = new Random(42);
+        var picker = new MorkBorgRandomPicker(refData, new Random(42));
 
-        Assert.False(string.IsNullOrEmpty(refData.GetRandomTrait(rng)), "Trait table returned empty");
-        Assert.False(string.IsNullOrEmpty(refData.GetRandomBody(rng)), "BrokenBody table returned empty");
-        Assert.False(string.IsNullOrEmpty(refData.GetRandomHabit(rng)), "BadHabit table returned empty");
+        Assert.False(string.IsNullOrEmpty(picker.PickTrait()), "Trait table returned empty");
+        Assert.False(string.IsNullOrEmpty(picker.PickBody()), "BrokenBody table returned empty");
+        Assert.False(string.IsNullOrEmpty(picker.PickHabit()), "BadHabit table returned empty");
     }
 
     [Fact]
@@ -678,11 +679,11 @@ public class WholeSystemAuditTests : MorkBorgGameRulesFixture
     public async Task C5_Names_NeverReturnEmpty()
     {
         var refData = await LoadGameReferenceDataAsync();
-        var rng = new Random(42);
+        var picker = new MorkBorgRandomPicker(refData, new Random(42));
 
         for (int i = 0; i < 100; i++)
         {
-            var name = refData.GetRandomName(rng);
+            var name = picker.PickName();
             Assert.False(string.IsNullOrWhiteSpace(name), $"Iteration {i}: name was empty");
         }
     }


### PR DESCRIPTION
## Summary

Extracts random selection behavior out of `MorkBorgReferenceDataService` into a dedicated `MorkBorgRandomPicker`.

This keeps the reference data service focused on loading data and indexed lookup, while callers that need random picks now depend on a focused collaborator built for that purpose.

## What changed

- Added `MorkBorgRandomPicker` to own random selection behavior
- Removed `GetRandom*()` methods from `MorkBorgReferenceDataService`
- Updated generation code to use the picker for random names, classes, traits, bodies, habits, and scrolls
- Updated non-DI construction in `CharacterGeneratorFactory` to wire in the picker
- Updated DI registration so runtime construction also includes the picker

## Why

`MorkBorgReferenceDataService` had become a convergence point for three separate concerns:

- loading JSON data
- indexed lookup by name or key
- random selection using `Random`

Pulling random selection into a dedicated picker makes the responsibilities cleaner, reduces coupling between data access and RNG behavior, and makes random-selection behavior easier to reason about and test independently.

## Notes

This addresses issue #43 and replaces the random-selection portion of #32.