### PR TITLE
Issue 44: extract generation delivery and acknowledgement out of handler

### DIFF
--- a/src/ScvmBot.Bot/Services/GenerateCommandHandler.cs
+++ b/src/ScvmBot.Bot/Services/GenerateCommandHandler.cs
@@ -120,52 +120,6 @@ public class GenerateCommandHandler : ISlashCommand
         return (embed, attachment, stream);
     }
 
-    private async Task DeliverAndAcknowledgeAsync(
-        ISlashCommandContext context,
-        GenerateResult result,
-        Embed embed,
-        FileAttachment? attachment,
-        CancellationToken ct)
-    {
-        bool sent;
-        try
-        {
-            sent = await _delivery.SendResultAsync(context, embed, attachment, ct);
-        }
-        catch (Exception sendEx)
-        {
-            _logger.LogError(sendEx, "Failed to deliver generation result via DM");
-            await context.FollowupAsync(
-                embed: ResponseCardBuilder.Build("Send Failed",
-                    "Something went wrong sending your result. Please try again.", new Color(200, 50, 50)),
-                ephemeral: true);
-            return;
-        }
-
-        if (!sent)
-        {
-            await context.FollowupAsync(
-                text: "I couldn't send you a DM. Please enable DMs from server members and try again.",
-                ephemeral: true);
-            return;
-        }
-
-        // Result was delivered successfully. The followup acknowledgement is
-        // best-effort — if it fails, the user already has their result.
-        try
-        {
-            var followupText = context.GuildId is null
-                ? (result.CharacterCount > 1 ? "Here are your characters!" : "Here's your character!")
-                : "Check your DMs.";
-            await context.FollowupAsync(text: followupText, ephemeral: true);
-        }
-        catch (Exception ackEx)
-        {
-            _logger.LogWarning(ackEx,
-                "Result delivered successfully but followup acknowledgement failed");
-        }
-    }
-
     public async Task HandleAsync(ISlashCommandContext context, CancellationToken ct = default)
     {
         await context.DeferAsync(ephemeral: true);
@@ -187,7 +141,7 @@ public class GenerateCommandHandler : ISlashCommand
             var (embed, attachment, stream) = RenderResult(result);
             try
             {
-                await DeliverAndAcknowledgeAsync(context, result, embed, attachment, ct);
+                await _delivery.DeliverAndAcknowledgeAsync(context, result, embed, attachment, ct);
             }
             finally
             {

--- a/src/ScvmBot.Bot/Services/GenerationDeliveryService.cs
+++ b/src/ScvmBot.Bot/Services/GenerationDeliveryService.cs
@@ -1,5 +1,6 @@
 using Discord;
 using Microsoft.Extensions.Logging;
+using ScvmBot.Modules;
 
 namespace ScvmBot.Bot.Services;
 
@@ -14,6 +15,58 @@ namespace ScvmBot.Bot.Services;
 /// </summary>
 public class GenerationDeliveryService(ILogger<GenerationDeliveryService> logger)
 {
+    /// <summary>
+    /// Sends the generation result and posts a followup acknowledgement.
+    /// Handles DM privacy failures and unexpected send exceptions inline,
+    /// posting appropriate error followups so the handler never needs to
+    /// reason about transport-layer outcomes.
+    /// </summary>
+    public async Task DeliverAndAcknowledgeAsync(
+        ISlashCommandContext context,
+        GenerateResult result,
+        Embed embed,
+        FileAttachment? attachment,
+        CancellationToken ct = default)
+    {
+        bool sent;
+        try
+        {
+            sent = await SendResultAsync(context, embed, attachment, ct);
+        }
+        catch (Exception sendEx)
+        {
+            logger.LogError(sendEx, "Failed to deliver generation result via DM");
+            await context.FollowupAsync(
+                embed: ResponseCardBuilder.Build("Send Failed",
+                    "Something went wrong sending your result. Please try again.", new Color(200, 50, 50)),
+                ephemeral: true);
+            return;
+        }
+
+        if (!sent)
+        {
+            await context.FollowupAsync(
+                text: "I couldn't send you a DM. Please enable DMs from server members and try again.",
+                ephemeral: true);
+            return;
+        }
+
+        // Result was delivered successfully. The followup acknowledgement is
+        // best-effort — if it fails, the user already has their result.
+        try
+        {
+            var followupText = context.GuildId is null
+                ? (result.CharacterCount > 1 ? "Here are your characters!" : "Here's your character!")
+                : "Check your DMs.";
+            await context.FollowupAsync(text: followupText, ephemeral: true);
+        }
+        catch (Exception ackEx)
+        {
+            logger.LogWarning(ackEx,
+                "Result delivered successfully but followup acknowledgement failed");
+        }
+    }
+
     /// <summary>
     /// Sends the generation result to the user's DM (or the interaction channel if
     /// already in a DM). Returns <c>true</c> if the message was sent successfully,


### PR DESCRIPTION
## Summary

Extracts Discord delivery and acknowledgement behavior out of `GenerateCommandHandler` into `GenerationDeliveryService`.

This keeps the command handler focused on parsing, routing, validation, and rendering orchestration while moving transport-layer delivery behavior into a dedicated service.

## What changed

- Removed `DeliverAndAcknowledgeAsync()` from `GenerateCommandHandler`
- Moved delivery and acknowledgement flow into `GenerationDeliveryService`
- Moved DM privacy handling into the delivery service
- Moved send failure handling into the delivery service
- Moved followup acknowledgement sequencing and acknowledgement failure isolation into the delivery service
- Updated `GenerateCommandHandler` to delegate delivery to the service

## Why

`GenerateCommandHandler` was mixing two different responsibilities:

- deciding what result to generate and render
- handling Discord-specific transport behavior for delivery and acknowledgement

This change separates those concerns so the handler owns generation orchestration and the delivery service owns the details of sending results to users.

## Notes

This addresses issue #44 and replaces the work previously tracked in #39.