### PR TITLE
Adding attribution and license exclusion for artwork from Thomas Kolvenbag

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -21,3 +21,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 Third-party licensing information is documented in: THIRD_PARTY_LICENSES.md
+
+---
+
+ARTWORK NOTICE
+
+The character sheet artwork used in the PDF export is by Thomas Kolvenbag and is
+NOT covered by this MIT licence. All rights to the artwork remain with the artist.
+The MIT licence applies to the software source code only.

--- a/README.md
+++ b/README.md
@@ -397,6 +397,12 @@ dotnet test tests/ScvmBot.Cli.Tests
 | Microsoft.Extensions.Hosting | 10.0.5 | DI / hosted service |
 | Microsoft.Extensions.Logging | 10.0.5 | Structured logging |
 
+## Artist Credit
+
+Character sheet artwork used in the PDF export is by **Thomas Kolvenbag**.
+
+The artwork is **not** covered by the MIT licence and is not included in the open-source distribution. All rights to the artwork remain with the artist.
+
 ## Licence
 
 [MIT](LICENSE) © 2025 Christopher Martin

--- a/docs/attribution.md
+++ b/docs/attribution.md
@@ -27,3 +27,11 @@ MÖRK BORG is © 2019 Ockult Örtmästare Games and Stockholm Kartell.
 ### License reference
 
 [https://morkborg.com/license/](https://morkborg.com/license/)
+
+---
+
+## Artwork
+
+The character sheet artwork used in the PDF export is by **Thomas Kolvenbag**.
+
+This artwork is **not** covered by the MIT licence. All rights remain with the artist. The open-source release of ScvmBot does not include or redistribute the artwork.

--- a/docs/mit.md
+++ b/docs/mit.md
@@ -31,3 +31,9 @@ SOFTWARE.
 ```
 
 Third-party licensing information is documented in [Third-Party Licenses]({{ site.baseurl }}/third-party-licenses).
+
+---
+
+## Artwork Notice
+
+The character sheet artwork used in the PDF export is by **Thomas Kolvenbag** and is **not** covered by the MIT licence above. All rights to the artwork remain with the artist. The MIT licence applies to the software source code only.


### PR DESCRIPTION
Adding attribution and license exclusion for artwork from Thomas Kolvenbag.

Added to 4 license and attribution files, as well as the readme.