### PR TITLE
63: Fix up /hello.

### DIFF
--- a/src/ScvmBot.Bot/Services/Commands/HelloCommand.cs
+++ b/src/ScvmBot.Bot/Services/Commands/HelloCommand.cs
@@ -14,5 +14,7 @@ public sealed class HelloCommand : ISlashCommand
             .WithContextTypes(InteractionContextType.Guild, InteractionContextType.BotDm, InteractionContextType.PrivateChannel);
 
     public Task HandleAsync(ISlashCommandContext context, CancellationToken ct = default) =>
-        context.RespondAsync($"Hello, {context.UserMention}! I'm ScvmBot!");
+        context.RespondAsync(
+            $"Hello, {context.UserMention}! I'm ScvmBot, a Discord bot for tabletop RPG character generation.\n\nUse **/generate** to create characters. MÖRK BORG is supported.",
+            ephemeral: true);
 }

--- a/src/ScvmBot.Bot/Services/Commands/ISlashCommandContext.cs
+++ b/src/ScvmBot.Bot/Services/Commands/ISlashCommandContext.cs
@@ -32,7 +32,7 @@ public interface ISlashCommandContext
     Task FollowupAsync(string? text = null, Embed? embed = null, bool ephemeral = false);
 
     /// <summary>Sends an immediate acknowledgement response to the interaction.</summary>
-    Task RespondAsync(string text);
+    Task RespondAsync(string text, bool ephemeral = false);
 
     /// <summary>Opens (or retrieves) the invoking user's direct-message channel.</summary>
     Task<IMessageChannel> CreateUserDMChannelAsync();

--- a/src/ScvmBot.Bot/Services/Commands/SocketSlashCommandContext.cs
+++ b/src/ScvmBot.Bot/Services/Commands/SocketSlashCommandContext.cs
@@ -28,8 +28,8 @@ internal sealed class SocketSlashCommandContext : ISlashCommandContext
     public Task FollowupAsync(string? text = null, Embed? embed = null, bool ephemeral = false) =>
         _command.FollowupAsync(text: text, embed: embed, ephemeral: ephemeral);
 
-    public Task RespondAsync(string text) =>
-        _command.RespondAsync(text: text);
+    public Task RespondAsync(string text, bool ephemeral = false) =>
+        _command.RespondAsync(text: text, ephemeral: ephemeral);
 
     public async Task<IMessageChannel> CreateUserDMChannelAsync() =>
         await _command.User.CreateDMChannelAsync();

--- a/tests/ScvmBot.Bot.Tests/DmGenerationTests.cs
+++ b/tests/ScvmBot.Bot.Tests/DmGenerationTests.cs
@@ -28,7 +28,7 @@ public class DmGenerationTests
     }
 
     [Fact]
-    public async Task HelloCommand_HandleAsync_RespondsWithUserMention()
+    public async Task HelloCommand_HandleAsync_RespondsEphemerallyWithUserMentionAndUsefulInfo()
     {
         var command = new HelloCommand();
         var context = new FakeCommandContext { UserMention = "<@123>" };
@@ -37,6 +37,8 @@ public class DmGenerationTests
 
         Assert.Single(context.RespondTexts);
         Assert.Contains("<@123>", context.RespondTexts[0]);
+        Assert.Contains("/generate", context.RespondTexts[0]);
+        Assert.True(context.RespondEphemerals[0], "Hello response must be ephemeral.");
     }
 
     private static GenerateCommandHandler CreateMinimalHandler() =>

--- a/tests/ScvmBot.Bot.Tests/TestInfrastructure.cs
+++ b/tests/ScvmBot.Bot.Tests/TestInfrastructure.cs
@@ -55,7 +55,9 @@ internal sealed class FakeCommandContext : ScvmBot.Bot.Services.ISlashCommandCon
         return Task.CompletedTask;
     }
 
-    public Task RespondAsync(string text) { RespondTexts.Add(text); return Task.CompletedTask; }
+    public List<bool> RespondEphemerals { get; } = new();
+
+    public Task RespondAsync(string text, bool ephemeral = false) { RespondTexts.Add(text); RespondEphemerals.Add(ephemeral); return Task.CompletedTask; }
 
     public Task<Discord.IMessageChannel> CreateUserDMChannelAsync()
     {


### PR DESCRIPTION
ISlashCommandContext.cs — Added bool ephemeral = false parameter to RespondAsync

SocketSlashCommandContext.cs — Passes ephemeral through to Discord.NET's RespondAsync

HelloCommand.cs — Response now includes useful info (bot purpose + /generate command hint) and is sent with ephemeral: true

TestInfrastructure.cs — FakeCommandContext now tracks RespondEphemerals alongside RespondTexts

DmGenerationTests.cs — Renamed and expanded the hello test to assert the response is ephemeral and contains /generate